### PR TITLE
changes to build in Docker-Container

### DIFF
--- a/container/build_leap_15_4/Dockerfile
+++ b/container/build_leap_15_4/Dockerfile
@@ -1,3 +1,23 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#  
+#  Copyright 2024 HPC-Gridware GmbH
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+###########################################################################
+#___INFO__MARK_END_NEW__
+
 # Use OpenSUSE Leap 15.4 as the base image
 FROM opensuse/leap:15.4
 

--- a/container/build_leap_15_4/Makefile
+++ b/container/build_leap_15_4/Makefile
@@ -1,3 +1,23 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#  
+#  Copyright 2024 HPC-Gridware GmbH
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+###########################################################################
+#___INFO__MARK_END_NEW__
+
 IMAGE_NAME=clusterscheduler-image-leap-154
 CONTAINER_NAME=clusterscheduler-leap-154
 MOUNT_DIR=$(shell pwd)/../..

--- a/container/build_rocky_9_3/Dockerfile
+++ b/container/build_rocky_9_3/Dockerfile
@@ -1,3 +1,23 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#  
+#  Copyright 2024 HPC-Gridware GmbH
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+###########################################################################
+#___INFO__MARK_END_NEW__
+
 # Use Rocky Linux 9.3 as the base image
 FROM rockylinux:9.3
 

--- a/container/build_rocky_9_3/Makefile
+++ b/container/build_rocky_9_3/Makefile
@@ -1,3 +1,23 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#  
+#  Copyright 2024 HPC-Gridware GmbH
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+###########################################################################
+#___INFO__MARK_END_NEW__
+
 IMAGE_NAME=clusterscheduler-image-rocky93
 CONTAINER_NAME=clusterscheduler-rocky93
 MOUNT_DIR=$(shell pwd)/../..

--- a/container/build_ubuntu2204/Dockerfile
+++ b/container/build_ubuntu2204/Dockerfile
@@ -1,3 +1,23 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#  
+#  Copyright 2024 HPC-Gridware GmbH
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+###########################################################################
+#___INFO__MARK_END_NEW__
+
 # Use Ubuntu 22.04 LTS as the base image
 FROM ubuntu:22.04
 
@@ -27,6 +47,8 @@ RUN apt-get update && apt-get install -y \
     libjemalloc-dev \
     hwloc \
     libhwloc-dev \
+    rapidjson-dev \
+    vim \
     && rm -rf /var/lib/apt/lists/*
 
 # Install a specific version of cmake if it is necessary. Here, install cmake 3.27.9 manually if needed.
@@ -42,7 +64,9 @@ RUN cd /tmp && \
     rm -rf /tmp/cmake-3.27.9 /tmp/cmake-3.27.9.tar.gz
 
 # Set work directory
-WORKDIR /clusterscheduler
+WORKDIR /build
+# Mountpoint for source code
+RUN mkdir /clusterscheduler
 
 # Clone the required repositories
 #RUN git clone https://github.com/hpc-gridware/clusterscheduler /clusterscheduler

--- a/container/build_ubuntu2204/Makefile
+++ b/container/build_ubuntu2204/Makefile
@@ -1,6 +1,26 @@
+#___INFO__MARK_BEGIN_NEW__
+###########################################################################
+#  
+#  Copyright 2024 HPC-Gridware GmbH
+#  
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#  
+#      http://www.apache.org/licenses/LICENSE-2.0
+#  
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#  
+###########################################################################
+#___INFO__MARK_END_NEW__
+
 IMAGE_NAME=clusterscheduler-image-ubuntu2204
 CONTAINER_NAME=clusterscheduler-ubuntu2204
-MOUNT_DIR=$(shell pwd)/../..
+MOUNT_DIR=$(shell pwd)/../../..
 
 .PHONY: build
 build:
@@ -10,6 +30,9 @@ build:
 .PHONY: run
 run:
 	@echo "Running Docker container with parent directory mounted..."
+	@echo "Build OCS: cmake -S /clusterscheduler/clusterscheduler [-DWITH_OS_3RDPARTY=ON]"
+	@echo "Build GCS: cmake -S /clusterscheduler/clusterscheduler -DPROJECT_EXTENSIONS=/clusterscheduler/gcs-extensions"
+	@echo "           -DPROJECT_FEATURES=gcs-extensions [-DWITH_OS_3RDPARTY=ON]"
 	docker run -it --rm --name $(CONTAINER_NAME) -v $(MOUNT_DIR):/clusterscheduler $(IMAGE_NAME)
 
 .PHONY: clean


### PR DESCRIPTION
* allow to build with WITH_OS_3RDPARTY=ON on Ubuntu 22
* set workdir to separate build directory
* mount directory above clusterscheduler to allow building with extensions
* copyright-header