### PR TITLE
Activation of reader-DS

### DIFF
--- a/doc/markdown/man/man5/sge_bootstrap.md
+++ b/doc/markdown/man/man5/sge_bootstrap.md
@@ -113,11 +113,15 @@ CSP security model).
 
 ## *listener_threads*
 
-The number of listener threads (defaults set by installation).
+The number of listener threads (allowed: 4-32, defaults set by installation). 
 
 ## *worker_threads*
 
-The number of worker threads (defaults set by installation).
+The number of worker threads (allowed: 4-32, defaults set by installation). 
+
+## *reader_threads*
+
+The number of reader threads (allowed: 4-32, defaults set by installation). 
 
 ## *scheduler_threads*
 

--- a/doc/markdown/man/man5/sge_conf.md
+++ b/doc/markdown/man/man5/sge_conf.md
@@ -699,6 +699,21 @@ they are just finished as they can't be rescheduled.
 If set to "true" or "1" xxQS_NAMExx triggers job rescheduling also when the host where the slave tasks of a 
 parallel job executes is in unknown state, if the *reschedule_unknown* parameter is activated.
 
+***MAX_DS_DEVIATION***
+
+Defines the maximum deviation in milliseconds between the main and secondary data stores. If the maximum deviation
+is reached, the system forces the secondary data stores to be updated. Valid values are in the range from 0 to 5000. 
+The default value is 1000.
+
+0 means that the secondary data stores are updated immediately whenever there is an offset between the main and secondary
+data stores. 5000 means that the secondary data stores are updated only when the offset is 5 seconds. In reality,
+the offset can be even larger because threads that use the secondary data stores must finish their work
+ before the update can be performed.
+
+Low values prevent parallelism in `sge_qmaster`, while high values either cause client commands such as `qstat` or `qhost`
+to display outdated information or cause the system to delay the response of commands that access secondary data stores
+till the update is performed. 
+
 ***MAX_DYN_EC***
 
 Sets the max number of dynamic event clients (as used by qsub -sync y and by xxQS_NAMExx DRMAA API library 

--- a/doc/markdown/man/man5/sge_conf.md
+++ b/doc/markdown/man/man5/sge_conf.md
@@ -613,6 +613,19 @@ The global configuration entry for this value may be overwritten by the executio
 
 A list of additional parameters can be passed to the xxQS_NAMExx qmaster. The following values are recognized:
 
+***DISABLE_SECONDARY_DS***
+
+Do not use this parameter. It is for internal use only.
+
+If this parameter is set, the use of all secondary data stores is disabled. This means that all requests will be 
+processed using data from the primary datastore only. The mode in which the system operates is similar to Sun/Some 
+Grid Engine, Univa Grid Engine or Altair Grid Engine, where there are no threads within qmaster or multiple 
+additional datastore's that could be used.
+
+Enabling this parameter in a running system will cause qmaster to complete the processing of pending requests 
+using secondary data stores. Existing threads will also be allowed to finish their work using those secondary data 
+stores but for new requests, they will utilize the primary datastore only.
+
 ***ENABLE_ENFORCE_MASTER_LIMIT***
 
 If this parameter is set then the *s_rt*, *h_rt* limit of a running job are tested and executed by the 

--- a/doc/markdown/man/man5/sge_conf.md
+++ b/doc/markdown/man/man5/sge_conf.md
@@ -615,7 +615,7 @@ A list of additional parameters can be passed to the xxQS_NAMExx qmaster. The fo
 
 ***DISABLE_SECONDARY_DS***
 
-Do not use this parameter. It is for internal use only.
+Do not use this parameter. It is for internal use only. Default is *false*.
 
 If this parameter is set, the use of all secondary data stores is disabled. This means that all requests will be 
 processed using data from the primary datastore only. The mode in which the system operates is similar to Sun/Some 
@@ -628,7 +628,7 @@ stores but for new requests, they will utilize the primary datastore only.
 
 ***DISABLE_SECONDARY_DS_EXECD***
 
-Do not use this parameter. It is for internal use only.
+Do not use this parameter. It is for internal use only. Default is *false*
 
 If this parameter is set, the use of all secondary data stores is disabled for requests coming from execution hosts.
 (see also *DISABLE_SECONDARY_DS* to disable data stores for all incoming requests).
@@ -636,6 +636,15 @@ If this parameter is set, the use of all secondary data stores is disabled for r
 Enabling this parameter in a running system will cause qmaster to complete the processing of pending requests
 using secondary data stores. Existing threads will also be allowed to finish their work using those secondary data
 stores but for new requests, they will utilize the primary datastore only.
+
+***DISABLE_SECONDARY_DS_READER***
+
+Do not use this parameter. It is for internal use only. Default depends on the product version. In product versions
+without automatic GDI sessions (e.g. OCS) the default is *true*, in product versions with automatic GDI sessions
+(newer GCS versions) the default is *false*.
+
+If this parameter is set to *true* then the use of those secondary data stores is disabled that could be utilized by
+read-only threads. This means that all requests will be processed using data from the primary datastore only.
 
 ***ENABLE_ENFORCE_MASTER_LIMIT***
 

--- a/doc/markdown/man/man5/sge_conf.md
+++ b/doc/markdown/man/man5/sge_conf.md
@@ -626,6 +626,17 @@ Enabling this parameter in a running system will cause qmaster to complete the p
 using secondary data stores. Existing threads will also be allowed to finish their work using those secondary data 
 stores but for new requests, they will utilize the primary datastore only.
 
+***DISABLE_SECONDARY_DS_EXECD***
+
+Do not use this parameter. It is for internal use only.
+
+If this parameter is set, the use of all secondary data stores is disabled for requests coming from execution hosts.
+(see also *DISABLE_SECONDARY_DS* to disable data stores for all incoming requests).
+
+Enabling this parameter in a running system will cause qmaster to complete the processing of pending requests
+using secondary data stores. Existing threads will also be allowed to finish their work using those secondary data
+stores but for new requests, they will utilize the primary datastore only.
+
 ***ENABLE_ENFORCE_MASTER_LIMIT***
 
 If this parameter is set then the *s_rt*, *h_rt* limit of a running job are tested and executed by the 

--- a/source/common/msg_common.h
+++ b/source/common/msg_common.h
@@ -47,6 +47,8 @@
 #define MSG_TABLE_SUM_F                            "SUM"
 #define MSG_TABLE_EV_ID                            "ID"
 #define MSG_TABLE_EV_NAME                          "NAME"
+#define MSG_TABLE_EV_POOL                          "POOL"
+#define MSG_TABLE_SIZE                             "SIZE"
 
 #define MSG_GDI_ARGUMENTSYNTAX_OA_ACCOUNT_STRING       "account_string          account_name"
 #define MSG_GDI_ARGUMENTSYNTAX_QA_BINDING_STRATEGY_EXP "exp                     explicit:<socket>,<core>[:...]"
@@ -917,6 +919,9 @@
 
 #define MSG_GDI_USAGE_scope_OPT                          "[-scope scope_name]"
 #define MSG_GDI_UTEXT_scope_OPT                          _MESSAGE(23517, _("switch the request scope"))
+
+#define MSG_GDI_USAGE_stl_OPT                            "[-stl]"
+#define MSG_GDI_UTEXT_stl_OPT                            _MESSAGE(23518, _("show thread pool list"))
 
 
 #define MSG_UNKNOWNREASON                 _MESSAGE(60000, _("<unknown reason>"))

--- a/source/common/sge_options.cc
+++ b/source/common/sge_options.cc
@@ -506,6 +506,8 @@ unsigned short sge_options[][ALL_OPT + 1] =
 /* sce_OPT, show ce object */
  {0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
 /* scel_OPT show ce object list */
+ {0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1},
+/* stl_OPT show thread list */
  {0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
 /*
   n  q  q  q  q  q  q  q  q  q  q  q  q  q  q  e  q  q  q  q  n  A

--- a/source/common/sge_options.h
+++ b/source/common/sge_options.h
@@ -293,7 +293,9 @@ enum {
    Mce_OPT, /* mod ce object */
    dce_OPT, /* del ce object */
    sce_OPT, /* show ce object */
-   scel_OPT /* show ce object list */
+   scel_OPT,/* show ce object list */
+
+   stl_OPT /* show thread list */
 };
 
 /* macros used in parsing */

--- a/source/common/usage.cc
+++ b/source/common/usage.cc
@@ -1137,6 +1137,10 @@ void sge_usage(u_long32 prog_number, FILE *fp) {
       MARK(OA_RQS_LIST);
    }
 
+   if (VALID_OPT(stl_OPT, prog_number)) {
+      PRINTITD(MSG_GDI_USAGE_stl_OPT, MSG_GDI_UTEXT_stl_OPT );
+   }
+
    if (VALID_OPT(sm_OPT, prog_number)) {
       PRINTITD(MSG_GDI_USAGE_sm_OPT , MSG_GDI_UTEXT_sm_OPT );
    }

--- a/source/daemons/qmaster/CMakeLists.txt
+++ b/source/daemons/qmaster/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
       sge_thread_signaler.cc
       sge_thread_timer.cc
       sge_thread_worker.cc
+      sge_thread_utility.cc
       sge_thread_reader.cc
       sge_userprj_qmaster.cc
       sge_userset_qmaster.cc

--- a/source/daemons/qmaster/CMakeLists.txt
+++ b/source/daemons/qmaster/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
       sge_thread_signaler.cc
       sge_thread_timer.cc
       sge_thread_worker.cc
+      sge_thread_reader.cc
       sge_userprj_qmaster.cc
       sge_userset_qmaster.cc
       sge_utility_qmaster.cc

--- a/source/daemons/qmaster/ocs_MirrorDataStore.cc
+++ b/source/daemons/qmaster/ocs_MirrorDataStore.cc
@@ -332,7 +332,7 @@ namespace ocs {
          // handle events (if shutdown is not pending)
          if (!do_shutdown) {
             const long wait_time = 200;
-            const long max_wait_time = 1000;
+            const long max_wait_time = mconf_get_max_ds_deviation();
             long remaining_wait_time = max_wait_time;
             bool did_handle_events = false;
             bool got_lock = false;

--- a/source/daemons/qmaster/ocs_MirrorDataStore.h
+++ b/source/daemons/qmaster/ocs_MirrorDataStore.h
@@ -34,14 +34,15 @@
 namespace ocs {
    class MirrorDataStore {
    private:
-      pthread_mutex_t mutex;              ///< used to secure other attributes within this object
-      pthread_cond_t cond_var;            ///< used to wait for new events and to wakeup this thread
-      const std::string mutex_name;       ///< unique mutex name
-      volatile bool triggered;            ///< true if new events are pending that need to get processed
-      lList *new_events;                  ///< new events that neet to get processed
-      ocs::DataStore::Id data_store_id;   ///< data store that is managed by this thread
-      pthread_t thread{};                 ///< pthread that handles the mirroring
-      sge_locktype_t lock_type;           ///< lock type used to secure the DS
+      pthread_mutex_t mutex;                       ///< used to secure other attributes within this object
+      pthread_cond_t cond_var;                     ///< used to wait for new events and to wakeup this thread
+      const std::string mutex_name;                ///< unique mutex name
+      volatile bool triggered;                     ///< true if new events are pending that need to get processed
+      lList *new_events;                           ///< new events that neet to get processed
+      ocs::DataStore::Id data_store_id;            ///< data store that is managed by this thread
+      pthread_t thread{};                          ///< pthread that handles the mirroring
+      sge_locktype_t lock_type;                    ///< lock type used to secure the DS
+      volatile bool did_handle_initial_events;     ///< true if the initial events have been handled and other threads can access the DS
 
       static void thread_cleanup_monitor(void *arg);
       static void thread_cleanup_event_client(void *arg);
@@ -56,6 +57,7 @@ namespace ocs {
 
       virtual void wait_for_event(lList **event_list);
       virtual void wakeup();
+      virtual void block_till_initial_events_handled();
 
       [[noreturn]] virtual void *main([[maybe_unused]] void *arg);
       virtual void subscribe_events() = 0;

--- a/source/daemons/qmaster/ocs_MirrorReaderDataStore.cc
+++ b/source/daemons/qmaster/ocs_MirrorReaderDataStore.cc
@@ -29,5 +29,6 @@ namespace ocs {
 
    void MirrorReaderDataStore::subscribe_events() {
       sge_mirror_subscribe(evc, SGE_TYPE_ALL, nullptr, nullptr, nullptr, nullptr, nullptr);
+      evc->ec_set_edtime(evc, 1);
    }
 }

--- a/source/daemons/qmaster/ocs_thread_mirror.cc
+++ b/source/daemons/qmaster/ocs_thread_mirror.cc
@@ -36,23 +36,29 @@ namespace ocs {
    void
    event_mirror_initialize() {
       DENTER(TOP_LAYER);
-      ocs::MirrorDataStore *mirror_thread;
 
-#if 0
       // create reader mirror
-      mirror_thread = new ocs::MirrorReaderDataStore();
-      Main_Control.mirror_thread_pool.push_back(mirror_thread);
-      pthread_create(&mirror_thread->thread, nullptr, event_mirror_main, mirror_thread);
-      DPRINTF("added event mirror thread for data store %d\n", mirror_thread->data_store_id);
-#endif
+      auto reader_mirror_thread = new ocs::MirrorReaderDataStore();
+      Main_Control.mirror_thread_pool.push_back(reader_mirror_thread);
+      pthread_create(&reader_mirror_thread->thread, nullptr, event_mirror_main, reader_mirror_thread);
+      DPRINTF("added event mirror thread for data store %d\n", reader_mirror_thread->data_store_id);
 
       // create listener mirror
-      mirror_thread = new ocs::MirrorListenerDataStore();
-      Main_Control.mirror_thread_pool.push_back(mirror_thread);
-      pthread_create(&mirror_thread->thread, nullptr, event_mirror_main, mirror_thread);
-      DPRINTF("added event mirror thread for data store %d\n", mirror_thread->data_store_id);
+      auto listener_mirror_thread = new ocs::MirrorListenerDataStore();
+      Main_Control.mirror_thread_pool.push_back(listener_mirror_thread);
+      pthread_create(&listener_mirror_thread->thread, nullptr, event_mirror_main, listener_mirror_thread);
+      DPRINTF("added event mirror thread for data store %d\n", listener_mirror_thread->data_store_id);
 
       DRETURN_VOID;
+   }
+
+   /** @brief Block until all initial events have been handled by the mirror threads
+    */
+   void
+   event_mirror_block_till_initial_events_handled() {
+      for (auto mirror_thread: Main_Control.mirror_thread_pool) {
+         mirror_thread->block_till_initial_events_handled();
+      }
    }
 
    void

--- a/source/daemons/qmaster/ocs_thread_mirror.h
+++ b/source/daemons/qmaster/ocs_thread_mirror.h
@@ -25,4 +25,7 @@ namespace ocs {
 
    void
    event_mirror_terminate();
+
+   void
+   event_mirror_block_till_initial_events_handled();
 }

--- a/source/daemons/qmaster/sge_c_gdi.cc
+++ b/source/daemons/qmaster/sge_c_gdi.cc
@@ -80,6 +80,7 @@
 #include "sge_ckpt_qmaster.h"
 #include "sge_hgroup_qmaster.h"
 #include "sge_sharetree_qmaster.h"
+#include "sge_thread_utility.h"
 #include "sge_qmod_qmaster.h"
 #include "sge_qmaster_threads.h"
 #include "msg_common.h"
@@ -499,6 +500,12 @@ sge_c_gdi_get_in_listener(gdi_object_t *ao, sge_gdi_packet_class_t *packet, sge_
    switch (task->target) {
       case SGE_EV_LIST:
          task->data_list = sge_select_event_clients("", task->condition, task->enumeration);
+         task->do_select_pack_simultaneous = false;
+         snprintf(SGE_EVENT, SGE_EVENT_SIZE, SFNMAX, MSG_GDI_OKNL);
+         answer_list_add(&(task->answer_list), SGE_EVENT, STATUS_OK, ANSWER_QUALITY_END);
+         DRETURN_VOID;
+      case SGE_DUMMY_LIST:
+         task->data_list = get_active_thread_list();
          task->do_select_pack_simultaneous = false;
          snprintf(SGE_EVENT, SGE_EVENT_SIZE, SFNMAX, MSG_GDI_OKNL);
          answer_list_add(&(task->answer_list), SGE_EVENT, STATUS_OK, ANSWER_QUALITY_END);
@@ -1546,6 +1553,7 @@ sge_task_check_get_perm_host(sge_gdi_packet_class_t *packet, sge_gdi_task_class_
       case SGE_SME_LIST:
       case SGE_RQS_LIST:
       case SGE_AR_LIST:
+      case SGE_DUMMY_LIST:
          /* host must be admin or submit host */
          if (!host_list_locate(*ocs::DataStore::get_master_list(SGE_TYPE_ADMINHOST), host) &&
              !host_list_locate(*ocs::DataStore::get_master_list(SGE_TYPE_SUBMITHOST), host)) {

--- a/source/daemons/qmaster/sge_qmaster_main.cc
+++ b/source/daemons/qmaster/sge_qmaster_main.cc
@@ -63,6 +63,7 @@
 #include "sge_thread_scheduler.h"
 #include "sge_thread_timer.h"
 #include "sge_thread_worker.h"
+#include "sge_thread_reader.h"
 #include "sge_thread_event_master.h"
 #include "setup_qmaster.h"
 #include "sge_host_qmaster.h"
@@ -270,6 +271,7 @@ int main(int argc, char *argv[]) {
 #endif
    sge_timer_initialize(&monitor);
    sge_worker_initialize();
+   sge_reader_initialize();
    sge_listener_initialize();
    sge_scheduler_initialize(nullptr);
 
@@ -286,6 +288,7 @@ int main(int argc, char *argv[]) {
     */
    sge_scheduler_terminate(nullptr);
    sge_listener_terminate();
+   sge_reader_terminate();
    sge_worker_terminate();
    sge_timer_terminate();
 #if defined (OGE_ENABLE_MIRROR_THREADS)

--- a/source/daemons/qmaster/sge_qmaster_main.cc
+++ b/source/daemons/qmaster/sge_qmaster_main.cc
@@ -287,10 +287,6 @@ int main(int argc, char *argv[]) {
 
    INFO("qmaster startup took %f seconds", sge_gmt64_to_gmt32_double(sge_get_gmt64() - start_time));
 
-   lList *active_thread_list = get_active_thread_list();
-   lWriteListTo(active_thread_list, stderr);
-   lFreeList(&active_thread_list);
-
    /*
     * Block till signal from signal thread arrives us
     */

--- a/source/daemons/qmaster/sge_qmaster_main.cc
+++ b/source/daemons/qmaster/sge_qmaster_main.cc
@@ -65,12 +65,14 @@
 #include "sge_thread_worker.h"
 #include "sge_thread_reader.h"
 #include "sge_thread_event_master.h"
+#include "sge_thread_utility.h"
 #include "setup_qmaster.h"
 #include "sge_host_qmaster.h"
 #include "qmaster_heartbeat.h"
 #include "shutdown.h"
 #include "sge_qmaster_threads.h"
 #include "msg_qmaster.h"
+
 
 #if defined(SOLARIS)
 #   include "sge_smf.h"
@@ -284,6 +286,10 @@ int main(int argc, char *argv[]) {
    sge_scheduler_initialize(nullptr);
 
    INFO("qmaster startup took %f seconds", sge_gmt64_to_gmt32_double(sge_get_gmt64() - start_time));
+
+   lList *active_thread_list = get_active_thread_list();
+   lWriteListTo(active_thread_list, stderr);
+   lFreeList(&active_thread_list);
 
    /*
     * Block till signal from signal thread arrives us

--- a/source/daemons/qmaster/sge_qmaster_main.cc
+++ b/source/daemons/qmaster/sge_qmaster_main.cc
@@ -265,12 +265,20 @@ int main(int argc, char *argv[]) {
     */
    sge_signaler_initialize();
    sge_event_master_initialize();
+
 #define OGE_ENABLE_MIRROR_THREADS
 #if defined(OGE_ENABLE_MIRROR_THREADS)
    ocs::event_mirror_initialize();
 #endif
+
    sge_timer_initialize(&monitor);
    sge_worker_initialize();
+
+#if defined(OGE_ENABLE_MIRROR_THREADS)
+   // before we start reader and listener we wait for the mirror threads to be ready
+   ocs::event_mirror_block_till_initial_events_handled();
+#endif
+
    sge_reader_initialize();
    sge_listener_initialize();
    sge_scheduler_initialize(nullptr);

--- a/source/daemons/qmaster/sge_qmaster_process_message.cc
+++ b/source/daemons/qmaster/sge_qmaster_process_message.cc
@@ -444,8 +444,14 @@ do_gdi_packet(struct_msg_t *aMsg, monitoring_t *monitor) {
       clear_packbuffer(&(packet->pb));
       sge_gdi_packet_free(&packet);
    } else if (ds_enabled && ds_type == ocs::DataStore::READER) {
+
+      // default is the reader request queue unless readers are disabled
+      sge_tq_queue_t *queue = ReaderRequestQueue;
+      if (mconf_get_disable_secondary_ds_reader()) {
+         queue = GlobalRequestQueue;
+      }
       packet->ds_type = ds_type;
-      sge_tq_store_notify(ReaderRequestQueue, SGE_TQ_GDI_PACKET, packet);
+      sge_tq_store_notify(queue, SGE_TQ_GDI_PACKET, packet);
    } else {
       DTRACE;
       // add to the worker request queue

--- a/source/daemons/qmaster/sge_qmaster_process_message.cc
+++ b/source/daemons/qmaster/sge_qmaster_process_message.cc
@@ -304,8 +304,9 @@ get_gdi_executor_ds(sge_gdi_packet_class_t *packet) {
          //    - termination of event client (SGE_EV_LIST)
          //    - start stop of thread (SGE_DUMMY_LIST)
          type = get_most_restrictive_datastore(type, ocs::DataStore::LISTENER);
-      } else if (operation == SGE_GDI_GET && target == SGE_EV_LIST) {
+      } else if (operation == SGE_GDI_GET && (target == SGE_EV_LIST || target == SGE_DUMMY_LIST)) {
          // show event client list (SGE_EV_LIST); data comes from event master therefor Listener DS possible
+         // show thread list (SGE_DUMMY_LIST); data comes from thread main therefor Listener DS possible
          type = get_most_restrictive_datastore(type, ocs::DataStore::LISTENER);
       } else if (operation == SGE_GDI_GET) {
          bool is_qconf = (strcmp(packet->commproc, prognames[QCONF]) == 0);

--- a/source/daemons/qmaster/sge_qmaster_process_message.cc
+++ b/source/daemons/qmaster/sge_qmaster_process_message.cc
@@ -274,8 +274,12 @@ get_gdi_executor_ds(sge_gdi_packet_class_t *packet) {
    if (packet->is_intern_request) {
       // Internal GDI requests will always be executed with access to the GLOBAL data store
       DRETURN(ocs::DataStore::GLOBAL);
-   } else if (strcmp(packet->commproc, prognames[EXECD]) == 0 || strcmp(packet->commproc, prognames[DRMAA]) == 0) {
-      // execd and DRMAA requests will always be executed with access to the GLOBAL data store
+   } else if (strcmp(packet->commproc, prognames[DRMAA]) == 0) {
+      // DRMAA requests will always be executed with access to the GLOBAL data store
+      // (@todo EB: as long as we do not have automatic GDI sessions)
+      DRETURN(ocs::DataStore::GLOBAL);
+   } else if (strcmp(packet->commproc, prognames[EXECD]) == 0 && mconf_get_disable_secondary_ds_execd()) {
+      // request coming from execd should be handled with GLOBAL DS if secondary DS are disabled for execd
       DRETURN(ocs::DataStore::GLOBAL);
    }
 

--- a/source/daemons/qmaster/sge_thread_listener.cc
+++ b/source/daemons/qmaster/sge_thread_listener.cc
@@ -53,6 +53,7 @@
 #include "setup_qmaster.h"
 #include "sge_thread_main.h"
 #include "sge_thread_listener.h"
+#include "sge_thread_utility.h"
 
 static void
 sge_listener_cleanup_monitor(monitoring_t *monitor) {

--- a/source/daemons/qmaster/sge_thread_main.cc
+++ b/source/daemons/qmaster/sge_thread_main.cc
@@ -51,6 +51,7 @@ main_control_t Main_Control = {
         nullptr,
         nullptr,
         nullptr,
+        nullptr,
         {},
 };
 

--- a/source/daemons/qmaster/sge_thread_main.h
+++ b/source/daemons/qmaster/sge_thread_main.h
@@ -46,8 +46,11 @@ typedef struct {
    /* exit state: 100 = another master took over */
    int exit_state;
 
-   /* Worker threads: handling incoming "intern GDI requests" */
+   /* Worker threads: handling incoming GDI requests (RW and RO) */
    cl_raw_list_t *worker_thread_pool;
+
+   /* Reader threads: handling incoming GDI requests (RO) */
+   cl_raw_list_t *reader_thread_pool;
 
    /* Message threads: accepting and answering certain commlib requests */
    cl_raw_list_t *listener_thread_pool;

--- a/source/daemons/qmaster/sge_thread_reader.cc
+++ b/source/daemons/qmaster/sge_thread_reader.cc
@@ -66,7 +66,7 @@ sge_reader_cleanup_monitor(void *arg) {
 
 void
 sge_reader_initialize() {
-   const int max_initial_reader_threads = bootstrap_get_worker_thread_count();
+   const int max_initial_reader_threads = bootstrap_get_reader_thread_count();
    cl_thread_settings_t *dummy_thread_p = nullptr;
 
    DENTER(TOP_LAYER);

--- a/source/daemons/qmaster/sge_thread_reader.cc
+++ b/source/daemons/qmaster/sge_thread_reader.cc
@@ -204,9 +204,9 @@ sge_reader_main(void *arg) {
           * acquire the correct lock
           */
          if (is_only_read_request) {
-            MONITOR_WAIT_TIME(SGE_LOCK(LOCK_GLOBAL, LOCK_READ), p_monitor);
+            MONITOR_WAIT_TIME(SGE_LOCK(LOCK_READER, LOCK_READ), p_monitor);
          } else {
-            MONITOR_WAIT_TIME(SGE_LOCK(LOCK_GLOBAL, LOCK_WRITE), p_monitor);
+            MONITOR_WAIT_TIME(SGE_LOCK(LOCK_READER, LOCK_WRITE), p_monitor);
          }
 
 #ifdef OBSERVE
@@ -216,6 +216,8 @@ sge_reader_main(void *arg) {
 
          // handle the request (GDI/Report/Ack ...
          if (packet->request_type == PACKET_GDI_REQUEST) {
+            // sge_usleep(3000000);
+
             task = packet->first_task;
             while (task != nullptr) {
                sge_c_gdi_process_in_worker(packet, task, &(task->answer_list), p_monitor);
@@ -252,9 +254,9 @@ sge_reader_main(void *arg) {
           * do unlock
           */
          if (is_only_read_request) {
-            SGE_UNLOCK(LOCK_GLOBAL, LOCK_READ);
+            SGE_UNLOCK(LOCK_READER, LOCK_READ);
          } else {
-            SGE_UNLOCK(LOCK_GLOBAL, LOCK_WRITE);
+            SGE_UNLOCK(LOCK_READER, LOCK_WRITE);
          }
 
          if (packet->request_type == PACKET_GDI_REQUEST) {

--- a/source/daemons/qmaster/sge_thread_reader.h
+++ b/source/daemons/qmaster/sge_thread_reader.h
@@ -1,0 +1,34 @@
+#pragma once
+/*___INFO__MARK_BEGIN_NEW__*/
+/***************************************************************************
+ *
+ *  Copyright 2024 HPC-Gridware GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ***************************************************************************/
+/*___INFO__MARK_END_NEW__*/
+
+#include <pthread.h>
+
+#include "sgeobj/sge_daemonize.h"
+#include "gdi/sge_gdi_packet.h"
+
+void
+sge_reader_initialize();
+
+void
+sge_reader_terminate();
+
+[[noreturn]] void *
+sge_reader_main(void *arg);

--- a/source/daemons/qmaster/sge_thread_scheduler.cc
+++ b/source/daemons/qmaster/sge_thread_scheduler.cc
@@ -937,3 +937,8 @@ sge_scheduler_main(void *arg) {
    // pthread_cleanup_push()/pthread_cleanup_pop() before the call of cl_thread_func_testcancel()
 }
 
+bool
+sge_scheduler_is_running() {
+   return Master_Scheduler.is_running;
+}
+

--- a/source/daemons/qmaster/sge_thread_scheduler.h
+++ b/source/daemons/qmaster/sge_thread_scheduler.h
@@ -50,3 +50,6 @@ sge_scheduler_terminate(lList **answer_list);
 
 [[noreturn]] void *
 sge_scheduler_main(void *arg);
+
+bool
+sge_scheduler_is_running();

--- a/source/daemons/qmaster/sge_thread_utility.cc
+++ b/source/daemons/qmaster/sge_thread_utility.cc
@@ -1,0 +1,88 @@
+/*___INFO__MARK_BEGIN_NEW__*/
+/***************************************************************************
+ *
+ *  Copyright 2024 HPC-Gridware GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ***************************************************************************/
+/*___INFO__MARK_END_NEW__*/
+
+#include "uti/sge_rmon_macros.h"
+#include "uti/sge_component.h"
+
+#include "cull/cull_list.h"
+#include "cull/cull_multitype.h"
+
+#include "sgeobj/sge_str.h"
+
+#include "sge_thread_utility.h"
+
+#include <sge_rmon_monitoring_level.h>
+#include <sge_thread_main.h>
+#include <sge_thread_scheduler.h>
+
+static void
+add_active_threads(cl_raw_list_t *threads, lList *active_thread_list) {
+   cl_thread_list_elem_t *thiz;
+   cl_thread_list_elem_t *next = cl_thread_list_get_first_elem(threads);
+
+   // Count the number of threads in the thread pool
+   const char *name = next->thread_config->thread_name;
+   int nthreads = 0;
+   while ((thiz = next) != nullptr) {
+      next = cl_thread_list_get_next_elem(thiz);
+      nthreads++;
+   }
+
+   // one entry per thread pool with the number of threads
+   lListElem *st_elem = lAddElemStr(&active_thread_list, ST_name, name, ST_Type);
+   lSetUlong(st_elem, ST_id, nthreads);
+}
+
+
+lList *
+get_active_thread_list() {
+   DENTER(TOP_LAYER);
+   lList *active_thread_list = lCreateList("", ST_Type);
+
+   // Internal threads where the user has no influence on, will not be shown
+#if 0
+   // static threads that cannot be disabled
+   lAddElemStr(&active_thread_list, ST_name, threadnames[SIGNAL_THREAD], ST_Type);
+   lAddElemStr(&active_thread_list, ST_name, threadnames[TIMER_THREAD], ST_Type);
+   lAddElemStr(&active_thread_list, ST_name, threadnames[EVENT_MASTER_THREAD], ST_Type);
+
+   // Mirror threads
+   add_active_threads(Main_Control.mirror_thread_pool, active_thread_list);
+
+   // Commlib threads
+   add_active_threads(cl_com_get_thread_list(), active_thread_list);
+#endif
+
+   // Scheduler thread if it is running
+   if (sge_scheduler_is_running()) {
+      lListElem *st_elem = lAddElemStr(&active_thread_list, ST_name, threadnames[SCHEDD_THREAD], ST_Type);
+      lSetUlong(st_elem, ST_id, 1);
+   }
+
+   // Thread pools with dynamic number of threads
+   add_active_threads(Main_Control.listener_thread_pool, active_thread_list);
+   add_active_threads(Main_Control.reader_thread_pool, active_thread_list);
+   add_active_threads(Main_Control.worker_thread_pool, active_thread_list);
+
+   // Sort the list
+   lPSortList(active_thread_list, "%I+", ST_name);
+
+   DRETURN(active_thread_list);
+}

--- a/source/daemons/qmaster/sge_thread_utility.h
+++ b/source/daemons/qmaster/sge_thread_utility.h
@@ -1,0 +1,25 @@
+#pragma once
+/*___INFO__MARK_BEGIN_NEW__*/
+/***************************************************************************
+ *
+ *  Copyright 2024 HPC-Gridware GmbH
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ ***************************************************************************/
+/*___INFO__MARK_END_NEW__*/
+
+#include "cull/cull_list.h"
+
+lList *
+get_active_thread_list();

--- a/source/dist/util/install_modules/inst_qmaster.sh
+++ b/source/dist/util/install_modules/inst_qmaster.sh
@@ -617,8 +617,9 @@ PrintBootstrap()
    $ECHO "binary_path             $SGE_ROOT_VAL/bin"
    $ECHO "qmaster_spool_dir       $QMDIR"
    $ECHO "security_mode           $PRODUCT_MODE"
-   $ECHO "listener_threads        2"
-   $ECHO "worker_threads          2"
+   $ECHO "listener_threads        4"
+   $ECHO "worker_threads          4"
+   $ECHO "reader_threads          4"
    $ECHO "scheduler_threads       1"
 }
 

--- a/source/dist/util/upgrade_modules/inst_upgrade.sh
+++ b/source/dist/util/upgrade_modules/inst_upgrade.sh
@@ -174,8 +174,9 @@ dbwriter.conf"
    cat $SGE_ROOT/$SGE_CELL/common/bootstrap | grep "threads" >/dev/null 2>&1
    do_bootstrap_upgrade=$?
    if [ $do_bootstrap_upgrade -eq 1 ]; then
-      $ECHO "listener_threads        2" >> $SGE_ROOT/$SGE_CELL/common/bootstrap
-      $ECHO "worker_threads          2" >> $SGE_ROOT/$SGE_CELL/common/bootstrap
+      $ECHO "listener_threads        4" >> $SGE_ROOT/$SGE_CELL/common/bootstrap
+      $ECHO "worker_threads          4" >> $SGE_ROOT/$SGE_CELL/common/bootstrap
+      $ECHO "reader_threads          4" >> $SGE_ROOT/$SGE_CELL/common/bootstrap
       $ECHO "scheduler_threads       1" >> $SGE_ROOT/$SGE_CELL/common/bootstrap
    fi
    

--- a/source/libs/comm/cl_commlib.cc
+++ b/source/libs/comm/cl_commlib.cc
@@ -764,7 +764,7 @@ int cl_com_setup_commlib(cl_thread_mode_t t_mode, cl_log_t debug_level, cl_log_f
                ret_val = cl_thread_list_create_thread(cl_com_thread_list,
                                                       &thread_p,
                                                       cl_com_log_list,
-                                                      "trigger_thread", 1, cl_com_trigger_thread, nullptr, nullptr,
+                                                      "com-trigger", 1, cl_com_trigger_thread, nullptr, nullptr,
                                                       CL_TT_COMMLIB);
                pthread_sigmask(SIG_SETMASK, &old_sigmask, nullptr);
             }
@@ -976,7 +976,6 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
    int usec_rest = 0;
    int full_usec_seconds = 0;
    int sec_param = 0;
-   char help_buffer[80];
    char *local_hostname = nullptr;
    struct in_addr local_addr;
    cl_handle_list_elem_t *elem = nullptr;
@@ -1525,7 +1524,6 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
 
 
          CL_LOG(CL_LOG_INFO, "starting handle service thread ...");
-         snprintf(help_buffer, 80, "%s_service", new_handle->local->comp_name);
          {
             sigset_t old_sigmask;
             sge_thread_block_all_signals(&old_sigmask);
@@ -1533,7 +1531,7 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
             return_value = cl_thread_list_create_thread(cl_com_thread_list,
                                                         &(new_handle->service_thread),
                                                         cl_com_log_list,
-                                                        help_buffer, 2, cl_com_handle_service_thread, nullptr,
+                                                        "com-service", 2, cl_com_handle_service_thread, nullptr,
                                                         (void *) new_handle, CL_TT_COMMLIB);
 
             pthread_sigmask(SIG_SETMASK, &old_sigmask, nullptr);
@@ -1546,7 +1544,6 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
          }
 
          CL_LOG(CL_LOG_INFO, "starting handle read thread ...");
-         snprintf(help_buffer, 80, "%s_read", new_handle->local->comp_name);
 
          {
             sigset_t old_sigmask;
@@ -1573,7 +1570,7 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
                return_value = cl_thread_list_create_thread(cl_com_thread_list,
                                                            &(new_handle->read_thread),
                                                            cl_com_log_list,
-                                                           help_buffer, 3, cl_com_handle_read_thread,
+                                                           "com-read", 3, cl_com_handle_read_thread,
                                                            cl_thread_read_write_thread_cleanup_function,
                                                            (void *) thread_data, CL_TT_COMMLIB);
                pthread_sigmask(SIG_SETMASK, &old_sigmask, nullptr);
@@ -1587,7 +1584,6 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
          }
 
          CL_LOG(CL_LOG_INFO, "starting handle write thread ...");
-         snprintf(help_buffer, 80, "%s_write", new_handle->local->comp_name);
 
          {
             sigset_t old_sigmask;
@@ -1614,7 +1610,7 @@ cl_com_handle_t *cl_com_create_handle(int *commlib_error,
                return_value = cl_thread_list_create_thread(cl_com_thread_list,
                                                            &(new_handle->write_thread),
                                                            cl_com_log_list,
-                                                           help_buffer, 2, cl_com_handle_write_thread,
+                                                           "com-write", 2, cl_com_handle_write_thread,
                                                            cl_thread_read_write_thread_cleanup_function,
                                                            (void *) thread_data, CL_TT_COMMLIB);
                pthread_sigmask(SIG_SETMASK, &old_sigmask, nullptr);
@@ -7764,4 +7760,13 @@ unsigned long cl_com_messages_in_send_queue(cl_com_handle_t *handle) {
    }
    return elems;
 }
+
+cl_raw_list_t *
+cl_com_get_thread_list() {
+   pthread_mutex_lock(&cl_com_thread_list_mutex);
+   cl_raw_list_t* thread_list = cl_com_thread_list;
+   pthread_mutex_unlock(&cl_com_thread_list_mutex);
+   return thread_list;
+}
+
 

--- a/source/libs/comm/cl_commlib.h
+++ b/source/libs/comm/cl_commlib.h
@@ -264,3 +264,5 @@ cl_commlib_get_last_message_time(cl_com_handle_t *handle, const char *un_resolve
 #endif
 
 int getuniquehostname(const char *hostin, char *hostout, int refresh_aliases);
+
+cl_raw_list_t * cl_com_get_thread_list();

--- a/source/libs/comm/lists/cl_thread.h
+++ b/source/libs/comm/lists/cl_thread.h
@@ -69,6 +69,7 @@ typedef enum cl_thread_type_def {
    CL_TT_COMMLIB,        /* commlib thread (do not use for threads created outside commlib) */
    CL_TT_LISTENER,       /* qmaster */
    CL_TT_WORKER,         /* qmaster */
+   CL_TT_READER,         /* qmaster */
    CL_TT_EVENT_MASTER,   /* qmaster */
    CL_TT_EVENT_MIRROR,   /* qmaster */
    CL_TT_SCHEDULER,      /* qmaster */

--- a/source/libs/gdi/sge_gdi_packet_internal.cc
+++ b/source/libs/gdi/sge_gdi_packet_internal.cc
@@ -62,7 +62,8 @@
 
 #define CLIENT_WAIT_TIME_S 1
 
-sge_tq_queue_t *Master_Task_Queue = nullptr;
+sge_tq_queue_t *GlobalRequestQueue = nullptr;
+sge_tq_queue_t *ReaderRequestQueue = nullptr;
 
 /****** gdi/request_internal/sge_gdi_packet_create_multi_answer() ***********
 *  NAME
@@ -751,7 +752,7 @@ sge_gdi_packet_execute_internal(lList **answer_list, sge_gdi_packet_class_t *pac
    /* 
     * append the packet to the packet list of the worker threads
     */
-   sge_tq_store_notify(Master_Task_Queue, SGE_TQ_GDI_PACKET, packet);
+   sge_tq_store_notify(GlobalRequestQueue, SGE_TQ_GDI_PACKET, packet);
    DRETURN(ret);
 }
 

--- a/source/libs/gdi/sge_gdi_packet_internal.h
+++ b/source/libs/gdi/sge_gdi_packet_internal.h
@@ -36,7 +36,8 @@
 #include "basis_types.h"
 #include "uti/sge_tq.h"
 
-extern sge_tq_queue_t *Master_Task_Queue;
+extern sge_tq_queue_t *GlobalRequestQueue;
+extern sge_tq_queue_t *ReaderRequestQueue;
 
 void
 sge_gdi_packet_wait_till_handled(sge_gdi_packet_class_t *packet);

--- a/source/libs/gdi/sge_gdi_packet_type.h
+++ b/source/libs/gdi/sge_gdi_packet_type.h
@@ -189,6 +189,9 @@ struct _sge_gdi_packet_class_t {
     */
    sge_pack_buffer pb;
 
+   // DS hint
+   u_long32 ds_type;
+
    /* 
     * if this packet is part of a packet queue then this
     * pointer might point to the next packet in the queue

--- a/source/libs/gdi/sge_security.cc
+++ b/source/libs/gdi/sge_security.cc
@@ -1307,7 +1307,6 @@ sge_gdi_packet_parse_auth_info(sge_gdi_packet_class_t *packet, lList **answer_li
                answer_list_add(answer_list, SGE_EVENT, STATUS_ENOMGR, ANSWER_QUALITY_ERROR);
                ret = false;
             }
-            DPRINTF("uid: \n" uid_t_fmt, uid);
             break;
          case 1:
             if (gid != nullptr && sscanf(token, gid_t_fmt, gid) != 1) {
@@ -1315,19 +1314,16 @@ sge_gdi_packet_parse_auth_info(sge_gdi_packet_class_t *packet, lList **answer_li
                answer_list_add(answer_list, SGE_EVENT, STATUS_ENOMGR, ANSWER_QUALITY_ERROR);
                ret = false;
             }
-            DPRINTF("gid: \n" gid_t_fmt, gid);
             break;
          case 2:
             if (user != nullptr) {
                sge_strlcpy(user, token, user_len);
             }
-            DPRINTF("user: %s\n", user);
             break;
          case 3:
             if (group) {
                sge_strlcpy(group, token, group_len);
             }
-            DPRINTF("group: %s\n", group);
             break;
          case 4:
             if (amount != nullptr && grp_array != nullptr) {
@@ -1345,7 +1341,6 @@ sge_gdi_packet_parse_auth_info(sge_gdi_packet_class_t *packet, lList **answer_li
                      break;
                   }
                }
-               DPRINTF("#supplementray groups: %d\n", *amount);
             }
             break;
          default:
@@ -1362,10 +1357,8 @@ sge_gdi_packet_parse_auth_info(sge_gdi_packet_class_t *packet, lList **answer_li
                      answer_list_add(answer_list, SGE_EVENT, STATUS_ENOMGR, ANSWER_QUALITY_ERROR);
                      ret = false;
                   }
-                  DPRINTF("supplementray grp id %d: " gid_t_fmt "\n", idx, (*grp_array)[idx].id);
                } else {
                   sge_strlcpy((*grp_array)[idx].name, token, sizeof((*grp_array)[idx].name));
-                  DPRINTF("supplementray grp name %d: %s\n", idx, (*grp_array)[idx].name);
                }
             } else {
                ERROR(SFNMAX, "unable to extract supplementary groups from auth_info (to many IDs)");

--- a/source/libs/sgeobj/ocs_DataStore.cc
+++ b/source/libs/sgeobj/ocs_DataStore.cc
@@ -124,8 +124,8 @@ namespace ocs {
 
       lList **ret;
       ret = &(obj_thread_shared.data_store[obj_state->ds_id].master_list[type]);
-      DPRINTF("ds: %d, type: %d, list: %p\n", obj_state->ds_id, type, *ret);
 #ifdef OBSERVE
+      DPRINTF("ds: %d, type: %d, list: %p\n", obj_state->ds_id, type, *ret);
       if (*obj_state->object_base[type].list) {
          lObserveChangeListType(*obj_state->object_base[type].list, true, obj_state->object_base[type].type_name);
       }

--- a/source/libs/sgeobj/ocs_DataStore.h
+++ b/source/libs/sgeobj/ocs_DataStore.h
@@ -21,6 +21,8 @@
 
 #include "sge_object.h"
 
+#include "sge_event.h"
+
 namespace ocs {
    class DataStore {
    private:
@@ -56,5 +58,16 @@ namespace ocs {
 
       static void
       free_all_master_lists();
+
+      static ev_registration_id
+      get_ev_id_for_data_store(ocs::DataStore::Id data_store_id) {
+         if (data_store_id == DataStore::LISTENER) {
+            return EV_ID_EVENT_MIRROR_LISTENER;
+         } else if (data_store_id == DataStore::READER) {
+            return EV_ID_EVENT_MIRROR_READER;
+         } else {
+            return EV_ID_ANY;
+         }
+      }
    };
 }

--- a/source/libs/sgeobj/sge_conf.cc
+++ b/source/libs/sgeobj/sge_conf.cc
@@ -149,6 +149,7 @@ static bool is_monitor_message = true;
 static bool use_qidle = false;
 static bool disable_reschedule = false;
 static bool disable_secondary_ds = false;
+static bool disable_secondary_ds_execd = false;
 static bool prof_listener_thrd = false;
 static bool prof_worker_thrd = false;
 static bool prof_signal_thrd = false;
@@ -669,6 +670,7 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
       use_qidle = false;
       disable_reschedule = false;   
       disable_secondary_ds = false;
+      disable_secondary_ds_execd = false;
       simulate_execds = false;
       simulate_jobs = false;
       prof_listener_thrd = false;
@@ -765,6 +767,9 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
             continue;
          }
          if (parse_bool_param(s, "DISABLE_SECONDARY_DS", &disable_secondary_ds)) {
+            continue;
+         }
+         if (parse_bool_param(s, "DISABLE_SECONDARY_DS_EXECD", &disable_secondary_ds_execd)) {
             continue;
          }
          if (parse_bool_param(s, "LOG_MONITOR_MESSAGE", &is_monitor_message)) {
@@ -2289,6 +2294,18 @@ bool mconf_get_disable_secondary_ds() {
    SGE_LOCK(LOCK_MASTER_CONF, LOCK_READ);
 
    ret = disable_secondary_ds;
+
+   SGE_UNLOCK(LOCK_MASTER_CONF, LOCK_READ);
+   DRETURN(ret);
+}
+
+bool mconf_get_disable_secondary_ds_execd() {
+   bool ret;
+
+   DENTER(BASIS_LAYER);
+   SGE_LOCK(LOCK_MASTER_CONF, LOCK_READ);
+
+   ret = disable_secondary_ds_execd;
 
    SGE_UNLOCK(LOCK_MASTER_CONF, LOCK_READ);
    DRETURN(ret);

--- a/source/libs/sgeobj/sge_conf.cc
+++ b/source/libs/sgeobj/sge_conf.cc
@@ -148,6 +148,7 @@ static bool do_authentication = true;
 static bool is_monitor_message = true;
 static bool use_qidle = false;
 static bool disable_reschedule = false;
+static bool disable_secondary_ds = false;
 static bool prof_listener_thrd = false;
 static bool prof_worker_thrd = false;
 static bool prof_signal_thrd = false;
@@ -667,6 +668,7 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
       spool_time = STREESPOOLTIMEDEF;
       use_qidle = false;
       disable_reschedule = false;   
+      disable_secondary_ds = false;
       simulate_execds = false;
       simulate_jobs = false;
       prof_listener_thrd = false;
@@ -760,6 +762,9 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
             continue;
          } 
          if (parse_bool_param(s, "DISABLE_AUTO_RESCHEDULING", &disable_reschedule)) {
+            continue;
+         }
+         if (parse_bool_param(s, "DISABLE_SECONDARY_DS", &disable_secondary_ds)) {
             continue;
          }
          if (parse_bool_param(s, "LOG_MONITOR_MESSAGE", &is_monitor_message)) {
@@ -2277,6 +2282,17 @@ bool mconf_get_disable_reschedule() {
    DRETURN(ret);
 }
 
+bool mconf_get_disable_secondary_ds() {
+   bool ret;
+
+   DENTER(BASIS_LAYER);
+   SGE_LOCK(LOCK_MASTER_CONF, LOCK_READ);
+
+   ret = disable_secondary_ds;
+
+   SGE_UNLOCK(LOCK_MASTER_CONF, LOCK_READ);
+   DRETURN(ret);
+}
 
 int mconf_get_scheduler_timeout() {
    int timeout;

--- a/source/libs/sgeobj/sge_conf.cc
+++ b/source/libs/sgeobj/sge_conf.cc
@@ -778,7 +778,7 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
             continue;
          }
          if (parse_int_param(s, "MAX_DS_DEVIATION", &max_ds_deviation, TYPE_TIM)) {
-            if (max_ds_deviation < 0 || max_ds_deviation > 3000) {
+            if (max_ds_deviation < 0 || max_ds_deviation > 5000) {
                max_ds_deviation = DEFAULT_DS_DEVIATION;
                answer_list_add_sprintf(answer_list, STATUS_ESYNTAX, ANSWER_QUALITY_WARNING,
                                        MSG_CONF_INVALIDPARAM_SSI, "qmaster_params", "MAX_DS_DEVIATION", DEFAULT_DS_DEVIATION);

--- a/source/libs/sgeobj/sge_conf.cc
+++ b/source/libs/sgeobj/sge_conf.cc
@@ -75,7 +75,7 @@ struct confel {                       /* cluster configuration parameters */
     char        *execd_spool_dir;     /* sge_spool directory base path */
     char        *mailer;              /* path to e-mail delivery agent */
     char        *xterm;               /* xterm path for interactive jobs */
-    char        *load_sensor;         /* path to a load sensor executable */    
+    char        *load_sensor;         /* path to a load sensor executable */
     char        *prolog;              /* start before jobscript may be none */
     char        *epilog;              /* start after jobscript may be none */
     char        *shell_start_mode;    /* script_from_stdin/posix_compliant/unix_behavior */
@@ -149,6 +149,8 @@ static bool is_monitor_message = true;
 static bool use_qidle = false;
 static bool disable_reschedule = false;
 static bool disable_secondary_ds = false;
+#define DEFAULT_DISABLE_SECONDARY_DS_READER (true)
+static bool disable_secondary_ds_reader = DEFAULT_DISABLE_SECONDARY_DS_READER;
 static bool disable_secondary_ds_execd = false;
 static bool prof_listener_thrd = false;
 static bool prof_worker_thrd = false;
@@ -675,6 +677,7 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
       use_qidle = false;
       disable_reschedule = false;   
       disable_secondary_ds = false;
+      disable_secondary_ds_reader = DEFAULT_DISABLE_SECONDARY_DS_READER;
       disable_secondary_ds_execd = false;
       simulate_execds = false;
       simulate_jobs = false;
@@ -772,6 +775,9 @@ int merge_configuration(lList **answer_list, u_long32 progid, const char *cell_r
             continue;
          }
          if (parse_bool_param(s, "DISABLE_SECONDARY_DS", &disable_secondary_ds)) {
+            continue;
+         }
+         if (parse_bool_param(s, "DISABLE_SECONDARY_DS_READER", &disable_secondary_ds_reader)) {
             continue;
          }
          if (parse_bool_param(s, "DISABLE_SECONDARY_DS_EXECD", &disable_secondary_ds_execd)) {
@@ -2307,6 +2313,18 @@ bool mconf_get_disable_secondary_ds() {
    SGE_LOCK(LOCK_MASTER_CONF, LOCK_READ);
 
    ret = disable_secondary_ds;
+
+   SGE_UNLOCK(LOCK_MASTER_CONF, LOCK_READ);
+   DRETURN(ret);
+}
+
+bool mconf_get_disable_secondary_ds_reader() {
+   bool ret;
+
+   DENTER(BASIS_LAYER);
+   SGE_LOCK(LOCK_MASTER_CONF, LOCK_READ);
+
+   ret = disable_secondary_ds_reader;
 
    SGE_UNLOCK(LOCK_MASTER_CONF, LOCK_READ);
    DRETURN(ret);

--- a/source/libs/sgeobj/sge_conf.h
+++ b/source/libs/sgeobj/sge_conf.h
@@ -147,6 +147,7 @@ void mconf_set_max_dynamic_event_clients(int value);
 bool mconf_get_set_lib_path();
 bool mconf_get_inherit_env();
 int mconf_get_spool_time();
+int mconf_get_max_ds_deviation();
 u_long32 mconf_get_monitor_time();
 bool mconf_get_do_accounting();
 bool mconf_get_do_reporting();

--- a/source/libs/sgeobj/sge_conf.h
+++ b/source/libs/sgeobj/sge_conf.h
@@ -139,6 +139,7 @@ char* mconf_get_notify_susp();
 int mconf_get_notify_kill_type();
 char* mconf_get_notify_kill();
 bool mconf_get_disable_reschedule();
+bool mconf_get_disable_secondary_ds();
 int mconf_get_scheduler_timeout();
 int mconf_get_max_dynamic_event_clients();
 void mconf_set_max_dynamic_event_clients(int value);

--- a/source/libs/sgeobj/sge_conf.h
+++ b/source/libs/sgeobj/sge_conf.h
@@ -140,6 +140,7 @@ int mconf_get_notify_kill_type();
 char* mconf_get_notify_kill();
 bool mconf_get_disable_reschedule();
 bool mconf_get_disable_secondary_ds();
+bool mconf_get_disable_secondary_ds_reader();
 bool mconf_get_disable_secondary_ds_execd();
 int mconf_get_scheduler_timeout();
 int mconf_get_max_dynamic_event_clients();

--- a/source/libs/sgeobj/sge_conf.h
+++ b/source/libs/sgeobj/sge_conf.h
@@ -140,6 +140,7 @@ int mconf_get_notify_kill_type();
 char* mconf_get_notify_kill();
 bool mconf_get_disable_reschedule();
 bool mconf_get_disable_secondary_ds();
+bool mconf_get_disable_secondary_ds_execd();
 int mconf_get_scheduler_timeout();
 int mconf_get_max_dynamic_event_clients();
 void mconf_set_max_dynamic_event_clients(int value);

--- a/source/libs/sgeobj/sge_event.h
+++ b/source/libs/sgeobj/sge_event.h
@@ -55,10 +55,11 @@ typedef enum {
 /* documentation see libs/evc/sge_event_client.c */
 typedef enum {
    EV_ID_INVALID = -1,
-   EV_ID_ANY = 0,            /* qmaster will give the ev a unique id */
-   EV_ID_SCHEDD = 1,         /* schedd registers at qmaster */
-   EV_ID_EVENT_MIRROR = 2,   // event mirror thread registers as event client
-   EV_ID_FIRST_DYNAMIC = 11  /* first id given by qmaster for EV_ID_ANY registration */
+   EV_ID_ANY = 0,                   /* qmaster will give the ev a unique id */
+   EV_ID_SCHEDD = 1,                /* schedd registers at qmaster */
+   EV_ID_EVENT_MIRROR_LISTENER = 2, // event mirror thread registers as event client
+   EV_ID_EVENT_MIRROR_READER = 3,   // event mirror thread registers as event client
+   EV_ID_FIRST_DYNAMIC = 11         /* first id given by qmaster for EV_ID_ANY registration */
 }ev_registration_id;
 
 /*-------------------------------------------*/

--- a/source/libs/uti/sge_bootstrap.cc
+++ b/source/libs/uti/sge_bootstrap.cc
@@ -190,7 +190,7 @@ set_security_mode(const char *security_mode) {
 }
 
 // FIFO_LOCK_QUEUE_LENGTH is big enough to allow up to 64 threads
-#define MAX_THREADS_PER_POOL (64)
+#define MAX_THREADS_PER_POOL (128)
 
 static void
 set_listener_thread_count(int thread_count) {
@@ -271,11 +271,13 @@ bootstrap_init_from_file() {
            {"ignore_fqdn",       true},
            {"spooling_method",   true},
            {"spooling_lib",      true},
+
            {"spooling_params",   true},
            {"binary_path",       true},
            {"qmaster_spool_dir", true},
            {"security_mode",     true},
            {"job_spooling",      false},
+
            {"listener_threads",  false},
            {"worker_threads",    false},
            {"reader_threads",    false},
@@ -312,6 +314,7 @@ bootstrap_init_from_file() {
       set_ignore_fqdn(val != 0);
       set_spooling_method(value[3]);
       set_spooling_lib(value[4]);
+
       set_spooling_params(value[5]);
       set_binary_path(value[6]);
       set_qmaster_spool_dir(value[7]);
@@ -322,13 +325,14 @@ bootstrap_init_from_file() {
       } else {
          set_job_spooling(true);
       }
+
       parse_ulong_val(nullptr, &val, TYPE_INT, value[10], nullptr, 0);
       set_listener_thread_count((int) val);
       parse_ulong_val(nullptr, &val, TYPE_INT, value[11], nullptr, 0);
       set_worker_thread_count((int) val);
-      parse_ulong_val(nullptr, &val, TYPE_INT, value[11], nullptr, 0);
-      set_reader_thread_count((int) val);
       parse_ulong_val(nullptr, &val, TYPE_INT, value[12], nullptr, 0);
+      set_reader_thread_count((int) val);
+      parse_ulong_val(nullptr, &val, TYPE_INT, value[13], nullptr, 0);
       set_scheduler_thread_count((int) val);
    }
 

--- a/source/libs/uti/sge_bootstrap.cc
+++ b/source/libs/uti/sge_bootstrap.cc
@@ -97,6 +97,7 @@ const char *threadnames[] = {
         "signal",        /* 6 */
         "scheduler",     /* 7 */
         "mirror",        /* 8 */
+        "reader",        /* 9 */
         nullptr
 };
 

--- a/source/libs/uti/sge_bootstrap.cc
+++ b/source/libs/uti/sge_bootstrap.cc
@@ -189,12 +189,15 @@ set_security_mode(const char *security_mode) {
    sge_bootstrap_tl1.security_mode = sge_strdup(sge_bootstrap_tl1.security_mode, security_mode);
 }
 
+// FIFO_LOCK_QUEUE_LENGTH is big enough to allow up to 64 threads
+#define MAX_THREADS_PER_POOL (64)
+
 static void
 set_listener_thread_count(int thread_count) {
    if (thread_count <= 0) {
       thread_count = 4;
-   } else if (thread_count > 32) {
-      thread_count = 32;
+   } else if (thread_count > MAX_THREADS_PER_POOL) {
+      thread_count = MAX_THREADS_PER_POOL;
    }
    sge_bootstrap_tl1.listener_thread_count = thread_count;
 }
@@ -203,8 +206,8 @@ static void
 set_worker_thread_count(int thread_count) {
    if (thread_count <= 0) {
       thread_count = 4;
-   } else if (thread_count > 32) {
-      thread_count = 32;
+   } else if (thread_count > MAX_THREADS_PER_POOL) {
+      thread_count = MAX_THREADS_PER_POOL;
    }
    sge_bootstrap_tl1.worker_thread_count = thread_count;
 }
@@ -213,8 +216,8 @@ static void
 set_reader_thread_count(int thread_count) {
    if (thread_count <= 0) {
       thread_count = 4;
-   } else if (thread_count > 32) {
-      thread_count = 32;
+   } else if (thread_count > MAX_THREADS_PER_POOL) {
+      thread_count = MAX_THREADS_PER_POOL;
    }
    sge_bootstrap_tl1.reader_thread_count = thread_count;
 }

--- a/source/libs/uti/sge_bootstrap.cc
+++ b/source/libs/uti/sge_bootstrap.cc
@@ -91,7 +91,7 @@ const char *prognames[] = {
 const char *threadnames[] = {
         "main",          /* 1 */
         "listener",      /* 2 */
-        "event_master",  /* 3 */
+        "event-master",  /* 3 */
         "timer",         /* 4 */
         "worker",        /* 5 */
         "signal",        /* 6 */

--- a/source/libs/uti/sge_bootstrap.h
+++ b/source/libs/uti/sge_bootstrap.h
@@ -84,4 +84,7 @@ int
 bootstrap_get_worker_thread_count();
 
 int
+bootstrap_get_reader_thread_count();
+
+int
 bootstrap_get_scheduler_thread_count();

--- a/source/libs/uti/sge_component.h
+++ b/source/libs/uti/sge_component.h
@@ -76,6 +76,7 @@ enum thread_type_t {
    SIGNAL_THREAD, // 6
    SCHEDD_THREAD, // 7
    EVENT_MIRROR_THREAD, // 8
+   READER_THREAD, // 9
 };
 
 extern const char *prognames[];

--- a/source/libs/uti/sge_lock.cc
+++ b/source/libs/uti/sge_lock.cc
@@ -196,7 +196,7 @@ void sge_try_lock(sge_locktype_t aType, sge_lockmode_t aMode, const char *func, 
 #else
 
 bool sge_try_lock(sge_locktype_t aType, sge_lockmode_t aMode, const char *func, sge_locker_t anID) {
-   int res = -1;
+   bool res = false;
 
 #ifdef SGE_DEBUG_LOCK_TIME
    struct timeval before;
@@ -214,15 +214,15 @@ bool sge_try_lock(sge_locktype_t aType, sge_lockmode_t aMode, const char *func, 
 
    if (aMode == LOCK_READ) {
 #ifdef SGE_USE_LOCK_FIFO
-      res = sge_fifo_try_lock(SGE_RW_Locks[aType], true) ? 0 : 1;
+      res = sge_fifo_try_lock(SGE_RW_Locks[aType], true);
 #else
-      res = pthread_rwlock_tryrdlock(SGE_RW_Locks[aType]);
+      res = (pthread_rwlock_tryrdlock(SGE_RW_Locks[aType]) == 0);
 #endif
    } else if (aMode == LOCK_WRITE) {
 #ifdef SGE_USE_LOCK_FIFO
-      res = sge_fifo_try_lock(SGE_RW_Locks[aType], false) ? 0 : 1;
+      res = sge_fifo_try_lock(SGE_RW_Locks[aType], false);
 #else
-      res = pthread_rwlock_trywrlock(SGE_RW_Locks[aType]);
+      res = (pthread_rwlock_trywrlock(SGE_RW_Locks[aType]) == 0);
 #endif
    } else {
       DPRINTF("wrong try lock type for global lock\n");

--- a/source/libs/uti/sge_lock.h
+++ b/source/libs/uti/sge_lock.h
@@ -61,8 +61,8 @@ typedef u_long64 sge_locker_t;
 typedef enum {
    LOCK_GLOBAL = 0,     // master lock for the main DS
    LOCK_SCHEDULER,      // lock for the scheduler data store
-   LOCK_READER,         // lock for the full read only snapshot providing a full copy (ro-requests)
    LOCK_LISTENER,       // lock for read only snapshot containing only auth data (listener-requests)
+   LOCK_READER,         // lock for the full read only snapshot providing a full copy (ro-requests)
    LOCK_MASTER_CONF,    // TODO: we should get rid of this.
 
    NUM_OF_LOCK_TYPES    // Total number of locks

--- a/test/daemons/qmaster/CMakeLists.txt
+++ b/test/daemons/qmaster/CMakeLists.txt
@@ -78,6 +78,7 @@ add_executable(test_qmaster_calendar
       ../../../source/daemons/qmaster/setup_qmaster.cc
       ../../../source/daemons/qmaster/sge_manop_qmaster.cc
       ../../../source/daemons/qmaster/sge_thread_signaler.cc
+      ../../../source/daemons/qmaster/sge_thread_utility.cc
       ../../../source/common/execution_states.cc
       ../../../source/common/sge_options.cc
       ../../../source/common/sig_handlers.cc


### PR DESCRIPTION
This implements the first set of changes of CS-270. It allows to enable the reader-DS additionally to the listener-DS that is already active. Furthermore it allows to utilize this DS by reader threads that have a message queue that might be filled with RO-requests (qstat, qhost, ...). This queue is disabled after a default installation because there are still no GDI sessions implemented. If the queue is enabled then as consequence the response for RO-requests can (and will) be slightly off from the main DS.