### PR TITLE
BF: CS-2719 man pages named the device isolation characteristic wrongly

### DIFF
--- a/doc/markdown/man/man5/sge_complex.md
+++ b/doc/markdown/man/man5/sge_complex.md
@@ -378,8 +378,8 @@ comparisons or in case of load scaling for the load complex entries:
 
         <id>[<char-name>=<char-value>,<char-name>=<char-value>,...]
 
-    Characteristics attach arbitrary typed metadata to one specific instance — the PCI device path of a
-    GPU, its on-board memory, a topology-affinity mask, a NIC's bandwidth, etc. Available in GCS only.
+    Characteristics attach typed metadata to one specific instance — the device files of a GPU, its
+    on-board memory, a topology-affinity mask, a NIC's bandwidth, etc. Available in GCS only.
     Multiple characteristics
     are separated by `,` (comma). The `,` inside the brackets is unambiguous because the flatfile
     parser is bracket-depth aware; the outer complex_values list separator is also `,`, so the two
@@ -388,7 +388,15 @@ comparisons or in case of load scaling for the load complex entries:
     parsed (so `memory=80G` is parsed as *MEMORY*, `bandwidth=100000` as *INT*, an affinity mask as
     *STRING*). A *char-value* may contain any byte except `,`, `]`, whitespace, `=`, `(`, and `)`;
     there is no quoting or escape mechanism. Characteristics cannot be attached to a range spec — list
-    ids explicitly (`gpu=3(0[device=/dev/nvidia0] 1[device=/dev/nvidia1] 2[device=/dev/nvidia2])`).
+    ids explicitly (`gpu=3(0[memory=80G] 1[memory=80G] 2[memory=80G])`).
+
+    Most characteristics are metadata that only a prolog or the job itself interprets, but one is
+    read by xxQS_NAMExx: a characteristic named *devices* lists the device files a job granted that
+    instance may use, and the execution daemon confines the job to them. Its value is a list of
+    device paths separated by `;`, each with an optional access mode after a `:`, which is `r`, `w`
+    or `rw`; a path given without a mode is granted read access. See xxqs_name_sxx_host_conf(5) for
+    an example. Because the name is what makes it work, a characteristic called *device* is an
+    ordinary piece of metadata and confines nothing.
 
     An id may appear more than once inside the `(...)` block to model N-way sharing of a single physical
     resource (e.g. `gpu=2(gpu0 gpu0)` — one GPU shared between two jobs). If any of the duplicate
@@ -401,8 +409,8 @@ comparisons or in case of load scaling for the load complex entries:
     Whitespace inside a `[...]` characteristics block is ignored, so a long RSMAP definition can be
     split across lines using the standard `\` + newline continuation:
 
-        complex_values GPU=2(gpu0[device=/dev/nvidia0,memory=80G,affinity_mask=SCCCCCCCCScccccccc] \
-                            gpu1[device=/dev/nvidia1,memory=80G,\
+        complex_values GPU=2(gpu0[devices=/dev/nvidia0:rw,memory=80G,affinity_mask=SCCCCCCCCScccccccc] \
+                            gpu1[devices=/dev/nvidia1:rw,memory=80G,\
                                  affinity_mask=SccccccccSCCCCCCCC])
 
     The line-continuation whitespace between `,` and the next characteristic is stripped before the
@@ -411,7 +419,7 @@ comparisons or in case of load scaling for the load complex entries:
 
     Example:
 
-        complex_values GPU=2(gpu0[device=/dev/nvidia0,memory=80G] gpu1[device=/dev/nvidia1,memory=80G])
+        complex_values GPU=2(gpu0[devices=/dev/nvidia0:rw,memory=80G] gpu1[devices=/dev/nvidia1:rw,memory=80G])
 
     The id list may be left out, in which case the value is just the amount:
 

--- a/doc/markdown/man/man5/sge_host_conf.md
+++ b/doc/markdown/man/man5/sge_host_conf.md
@@ -90,14 +90,23 @@ associated with the host.
 For a Resource Map (*RSMAP*, see xxqs_name_sxx_complex(5)) the value on the right of the `=` names the
 individual instances the host provides, and may attach per-instance characteristics inside square
 brackets. Per-instance characteristics are available in GCS only. Example — a host with two NVIDIA
-GPUs, each carrying a device path, on-board memory, and a topology affinity mask:
+GPUs, each carrying its device files, on-board memory, and a topology affinity mask:
 
-    complex_values GPU=2(gpu0[device=/dev/nvidia0,memory=80G,affinity_mask=SCCCCCCCCScccccccc] \
-                        gpu1[device=/dev/nvidia1,memory=80G,affinity_mask=SccccccccSCCCCCCCC])
+    complex_values GPU=2(gpu0[devices=/dev/nvidia0:rw;/dev/nvidiactl:r,memory=80G,\
+                              affinity_mask=SCCCCCCCCScccccccc] \
+                         gpu1[devices=/dev/nvidia1:rw;/dev/nvidiactl:r,memory=80G,\
+                              affinity_mask=SccccccccSCCCCCCCC])
 
-Each characteristic name (`device`, `memory`, `affinity_mask` in the example) must already be defined
-as a complex before it can be attached to an RSMAP instance; the referenced complex's
+Each characteristic name (`devices`, `memory`, `affinity_mask` in the example) must already be
+defined as a complex before it can be attached to an RSMAP instance; the referenced complex's
 type governs how the value is parsed. See xxqs_name_sxx_complex(5) for the full grammar.
+
+The name *devices* is not just a label: a job granted an instance is confined to the device files
+listed there, so it reaches the GPU it was given and none of the others. The value is a list of
+device paths separated by `;`, each with an optional access mode after a `:` — `r`, `w` or `rw`. A
+path written without a mode is granted read access, which is why both paths above name one
+explicitly. The remaining characteristics in the example are ordinary metadata; nothing reads them
+unless a prolog or the job itself does.
 
 A *RSMAP* may also be written as a plain amount, without naming the instances. They are then named `0`
 to *amount*-1, so


### PR DESCRIPTION
Device isolation is driven by an RSMAP characteristic named "devices", whose value is a ";" separated list of device paths, each with an optional access mode after a ":" - r, w or rw, read when the mode is left out.

sge_complex.5 and sge_host_conf.5 showed it as "device", singular, holding a single path and no access mode, and neither mentioned "devices" at all. The examples do not read as placeholder names - they are paths under /dev in a section about attaching hardware metadata to RSMAP instances - so an administrator setting up GPU isolation would follow them.

Doing so fails silently. A characteristic named "device" is perfectly legal, since any complex may be used as one, so the configuration is accepted, spooled and passed to the execution daemon. It simply never confines anything, because the execution daemon looks for "devices" (LOAD_ATTR_DEVICES). Nothing is logged, and every job on the host can reach every GPU on it.

Both pages now use "devices" with the real syntax, document the value format, and say what the characteristic does rather than presenting it as one more piece of arbitrary metadata. Where an example only needs a second characteristic, it uses a plain placeholder instead of a near miss of a name the system actually reads.

The material was already correct in the admin guide and the release notes; only the two man pages had drifted.


Claude-Session: https://claude.ai/code/session_01NwLismbU7EuupEkCFkGZYv